### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-common to 3.3.3

### DIFF
--- a/flink-learning-connectors/flink-learning-connectors-hbase/pom.xml
+++ b/flink-learning-connectors/flink-learning-connectors-hbase/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.7.4</version>
+            <version>3.3.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/flink-learning-sql/flink-learning-sql-blink/pom.xml
+++ b/flink-learning-sql/flink-learning-sql-blink/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.7.4</version>
+            <version>3.3.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hadoop:hadoop-common 2.7.4
- [CVE-2017-15713](https://www.oscs1024.com/hd/CVE-2017-15713)


### What did I do？
Upgrade org.apache.hadoop:hadoop-common from 2.7.4 to 3.3.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS