### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/flink-learning-basic/flink-learning-data-sinks/pom.xml
+++ b/flink-learning-basic/flink-learning-data-sinks/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
+            <version>8.0.28</version>
         </dependency>
     </dependencies>
 

--- a/flink-learning-basic/flink-learning-data-sources/pom.xml
+++ b/flink-learning-basic/flink-learning-data-sources/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
+            <version>8.0.28</version>
         </dependency>
     </dependencies>
 

--- a/flink-learning-connectors/flink-learning-connectors-mysql/pom.xml
+++ b/flink-learning-connectors/flink-learning-connectors-mysql/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
+            <version>8.0.28</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-learning-examples/pom.xml
+++ b/flink-learning-examples/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
+            <version>8.0.28</version>
         </dependency>
     </dependencies>
     <build>

--- a/flink-learning-monitor/flink-learning-monitor-alert/pom.xml
+++ b/flink-learning-monitor/flink-learning-monitor-alert/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
+            <version>8.0.28</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in mysql:mysql-connector-java 5.1.34
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)


### What did I do？
Upgrade mysql:mysql-connector-java from 5.1.34 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS