### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.5.1

### DIFF
--- a/flink-learning-sql/flink-learning-sql-blink/pom.xml
+++ b/flink-learning-sql/flink-learning-sql-blink/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.3.3</version>
+            <version>42.5.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.3.3
- [CVE-2022-31197](https://www.oscs1024.com/hd/CVE-2022-31197)


### What did I do？
Upgrade org.postgresql:postgresql from 42.3.3 to 42.5.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS